### PR TITLE
Filter out paths sent to "man"

### DIFF
--- a/esh-help.el
+++ b/esh-help.el
@@ -94,12 +94,13 @@ It comes from Zsh."
 (defun esh-help-eldoc-help-string (cmd)
   "Return minibuffer help string for CMD."
   (cond
-    ((eshell-find-alias-function cmd)
-     (esh-help--get-fnsym-args-string (eshell-find-alias-function cmd)))
-    ((string-match-p "^\\*." cmd)
-     (esh-help-eldoc-man-minibuffer-string (substring cmd 1)))
-    ((eshell-search-path cmd) (esh-help-eldoc-man-minibuffer-string cmd))
-    ((functionp (intern cmd)) (esh-help--get-fnsym-args-string (intern cmd)))))
+   ((string-match-p "^[/.]" cmd) nil)
+   ((eshell-find-alias-function cmd)
+    (esh-help--get-fnsym-args-string (eshell-find-alias-function cmd)))
+   ((string-match-p "^\\*." cmd)
+    (esh-help-eldoc-man-minibuffer-string (substring cmd 1)))
+   ((eshell-search-path cmd) (esh-help-eldoc-man-minibuffer-string cmd))
+   ((functionp (intern cmd)) (esh-help--get-fnsym-args-string (intern cmd)))))
 
 (defun esh-help-man-string (cmd)
   "Return help string for the shell command CMD."


### PR DESCRIPTION
When "man" sees a "/" or a "." at the beginning of the cmd, it assumes that we
are looking up a man file like /foo.5.gz. This is probably not what we want, and
it results in lots of "eldoc error: (wrong-type-argument stringp nil)" error
messages for me.